### PR TITLE
Unit test fix

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,7 +4,6 @@ use nom::{
     error::Error as NomError,
     IResult,
     sequence::tuple,
-    number::streaming::be_u8
 };
 
 
@@ -85,6 +84,7 @@ fn parse_spacepacket<T>(bytes: &[u8], sec_header_parser: fn(&[u8]) -> IResult<&[
 #[cfg(test)]
 mod tests {
     use super::*;
+    use nom::number::streaming::be_u8;
 
     #[derive(Clone,Debug,PartialEq,Eq)]
     pub struct SecondaryHeader {
@@ -170,7 +170,7 @@ mod tests {
             payload: &[255]
         };
 
-        let (remaining, parsed) = parse_spacepacket::<SecondaryHeader>(raw, sec_header_parser).expect("failed to parse space packet");
+        let (_remaining, parsed) = parse_spacepacket::<SecondaryHeader>(raw, sec_header_parser).expect("failed to parse space packet");
 
         assert_eq!(parsed, expected);
     }    

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -64,18 +64,14 @@ pub fn primary_header(input: &[u8] ) -> IResult<&[u8], PrimaryHeader> {
 
 //make sec_header_parser optional if you just want to parse generic, no-sec-headers spacepackets
 fn parse_spacepacket<T>(bytes: &[u8], sec_header_parser: fn(&[u8]) -> IResult<&[u8], T>) -> IResult<&[u8], SpacePacket<T>> {
-
     let (remaining, pri_header) = primary_header(bytes).expect("failed to parse primary header");
 
-    let sec_header = None;
-    dbg!(remaining);
-    if (pri_header.sec_header_flag == 1) {
-        let (remaining, sec_header) = sec_header_parser(remaining).expect("failed to parse secondary header");
-
-        let sec_header = Some(sec_header);
-        dbg!(remaining);
-        //its a scope issue preventing the value of the sec header form leaving this scope
-    }
+    let (remaining, sec_header) = if pri_header.sec_header_flag == 1 {
+        let (remaining, parsed_sec_header) = sec_header_parser(remaining).expect("failed to parse secondary header");
+        (remaining, Some(parsed_sec_header))
+    } else {
+        (remaining, None)
+    };
 
     Ok((remaining, SpacePacket::<T> {
         primary_header: pri_header,


### PR DESCRIPTION
Here are the changes to make `parse_python_spacepacket` pass. There are also some changes to silence some warnings emitted by the Rust compiler, and I ran rustfmt to format the code nicely. The commit that actually fixes the unit test is 
297cf81076aed8e1377a49bded21336714f0c616.