### PR TITLE
Create macros that allow users to automatically implement conversions between any type and PacketType and SecondaryHeaderFlag

### DIFF
--- a/src/primaryheader.rs
+++ b/src/primaryheader.rs
@@ -71,10 +71,10 @@ impl PrimaryHeader {
 
     fn to_bytes(&self) -> ParseResult<Vec<u8>> {
         let mut bytes = vec![];
-        //TODO: look into this two-stage casting from enum to u16
+        
         let header_0: u16 = (self.app_proc_id) as u16
-            | u16::from(self.sec_header_flag as u8) << 11
-            | u16::from(self.packet_type as u8) << 12
+            | u16::from(self.sec_header_flag) << 11
+            | u16::from(self.packet_type) << 12
             | u16::from(self.version) << 13;
 
         let header_1 = (self.sequence_count as u16)

--- a/src/primaryheader.rs
+++ b/src/primaryheader.rs
@@ -18,10 +18,10 @@
 
 // use crate::packet::{LinkPacket, PayloadType};
 // use crate::CommsResult;
+use crate::types;
+use crate::ParseResult;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use std::io::Cursor;
-use crate::ParseResult;
-use crate::types;
 
 #[derive(Eq, Debug, PartialEq, Clone)]
 pub struct PrimaryHeader {
@@ -41,9 +41,7 @@ pub struct PrimaryHeader {
     pub data_length: u16,
 }
 
-
 impl PrimaryHeader {
-
     fn parse(raw: &[u8]) -> ParseResult<PrimaryHeader> {
         let mut reader = Cursor::new(raw.to_vec());
 
@@ -59,26 +57,25 @@ impl PrimaryHeader {
 
         let data_length = reader.read_u16::<BigEndian>()?;
         Ok(PrimaryHeader {
-                version,
-                packet_type,
-                sec_header_flag,
-                app_proc_id,
-                sequence_flags,
-                sequence_count,
-                data_length,
-            })
+            version,
+            packet_type,
+            sec_header_flag,
+            app_proc_id,
+            sequence_flags,
+            sequence_count,
+            data_length,
+        })
     }
 
     fn to_bytes(&self) -> ParseResult<Vec<u8>> {
         let mut bytes = vec![];
-        
+
         let header_0: u16 = (self.app_proc_id) as u16
             | u16::from(self.sec_header_flag) << 11
             | u16::from(self.packet_type) << 12
             | u16::from(self.version) << 13;
 
-        let header_1 = (self.sequence_count as u16)
-            | u16::from(self.sequence_flags) << 14;
+        let header_1 = (self.sequence_count as u16) | u16::from(self.sequence_flags) << 14;
 
         let header_2 = self.data_length;
 
@@ -92,8 +89,8 @@ impl PrimaryHeader {
 
 #[cfg(test)]
 mod tests {
-    use crate::*;
     use crate::primaryheader::PrimaryHeader;
+    use crate::*;
 
     #[test]
     fn parse_python_spacepacket_primary_header() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -21,25 +21,36 @@ impl Default for PacketType {
     }
 }
 
-impl From<u8> for PacketType {
-    fn from(byte: u8) -> PacketType {
-        match byte {
-            0 => PacketType::Data,
-            1 => PacketType::Command,
-            _ => PacketType::Unknown
-        }
-    }
+/// Macro for generating implementations of [`From<T>`] for [`PacketType`]
+/// and [`From<PacketType>`] for `T` for some type `T`.
+macro_rules! impl_packet_type_conv {
+    ( $($T:ty)+ ) => {
+        $(
+            impl From<$T> for $crate::types::PacketType {
+                fn from(byte: $T) -> $crate::types::PacketType {
+                    match byte {
+                        0 => $crate::types::PacketType::Data,
+                        1 => $crate::types::PacketType::Command,
+                        _ => $crate::types::PacketType::Unknown,
+                    }
+                }
+            }
+
+            impl From<$crate::types::PacketType> for $T {
+                fn from(packet_type: $crate::types::PacketType) -> $T {
+                    match packet_type {
+                        $crate::types::PacketType::Data | $crate::types::PacketType::Unknown => 0,
+                        $crate::types::PacketType::Command => 1,
+                    }
+                }
+            }
+        )+
+    };
 }
 
-impl From<PacketType> for u8 {
-    fn from(packet_type: PacketType) -> u8 {
-        match packet_type { 
-            PacketType::Data    => 0,
-            PacketType::Command => 1,
-            PacketType::Unknown => 0,
-        }
-    }
-}
+// To add implementations for more types, just add them to the list of types being
+// passed to the invocation of impl_packet_type_conv here.
+impl_packet_type_conv! { u8 u16 }
 
 /// The secondary header flag indicates whether there is another header
 /// following the primary header (Present) or not (NotPresent).
@@ -62,26 +73,36 @@ impl Default for SecondaryHeaderFlag {
     }
 }
 
-impl From<u8> for SecondaryHeaderFlag {
-    fn from(byte: u8) -> SecondaryHeaderFlag {
-        match byte {
-            0 => SecondaryHeaderFlag::NotPresent,
-            1 => SecondaryHeaderFlag::Present,
-            _ => SecondaryHeaderFlag::Unknown
-        }
-    }
+/// Macro for generating implementations of [`From<T>`] for [`SecondaryHeaderFlag`]
+/// and [`From<SecondaryHeaderFlag>`] for `T` for some type `T`.
+macro_rules! impl_sec_header_flag_conv {
+    ( $($T:ty)+ ) => {
+        $(
+            impl From<$T> for $crate::types::SecondaryHeaderFlag {
+                fn from(byte: $T) -> $crate::types::SecondaryHeaderFlag {
+                    match byte {
+                        0 => $crate::types::SecondaryHeaderFlag::NotPresent,
+                        1 => $crate::types::SecondaryHeaderFlag::Present,
+                        _ => $crate::types::SecondaryHeaderFlag::Unknown,
+                    }
+                }
+            }
+
+            impl From<$crate::types::SecondaryHeaderFlag> for $T {
+                fn from(packet_type: $crate::types::SecondaryHeaderFlag) -> $T {
+                    match packet_type {
+                        $crate::types::SecondaryHeaderFlag::NotPresent | $crate::types::SecondaryHeaderFlag::Unknown => 0,
+                        $crate::types::SecondaryHeaderFlag::Present => 1,
+                    }
+                }
+            }
+        )+
+    };
 }
 
-impl From<SecondaryHeaderFlag> for u8 {
-    fn from(flag: SecondaryHeaderFlag) -> u8 {
-        match flag {
-            SecondaryHeaderFlag::NotPresent => 0,
-            SecondaryHeaderFlag::Present    => 1,
-            SecondaryHeaderFlag::Unknown    => 0
-        }
-    }
-}
-
+// To add implementations for more types, just add them to the list of types being
+// passed to the invocation of impl_sec_header_flag_conv here.
+impl_sec_header_flag_conv! { u8 u16 }
 
 /// The sequence flag indicates the interpretation of the sequence count.
 /// Continuation- the sequence count indicates the block in a series of packets

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,19 +1,18 @@
 // This file contains type definitions for various fields used within the PrimaryHeader and other parts of the space packet
 // It is derived from Apache 2.0-licensed work done by Noah Ryan in https://github.com/nsmryan/ccsds_primary_header/blob/master/src/primary_header.rs
 
-
-/// The PacketType indicates whether the packet is a command (Command) or a 
+/// The PacketType indicates whether the packet is a command (Command) or a
 /// telemetry (Data) packet.
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum PacketType {
-  /// The packet contains telemetry data.
-  Data,
-  /// The packet contains a command.
-  Command,
-  /// The packet type is unknown. This should not occur, but it is included
-  /// for encoding an integer into a packet type.
-  Unknown
-} 
+    /// The packet contains telemetry data.
+    Data,
+    /// The packet contains a command.
+    Command,
+    /// The packet type is unknown. This should not occur, but it is included
+    /// for encoding an integer into a packet type.
+    Unknown,
+}
 
 impl Default for PacketType {
     fn default() -> PacketType {
@@ -56,16 +55,16 @@ impl_packet_type_conv! { u8 u16 }
 /// following the primary header (Present) or not (NotPresent).
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum SecondaryHeaderFlag {
-  /// The secondary header is not present. The bytes following the primary header
-  /// is the packet's data section.
-  NotPresent,
-  /// A secondary header is present in the packet. The secondary header follows the
-  /// primary header.
-  Present,
-  /// The secondary header flag in not valid. This should not occur, but it is included
-  /// for turning an integer into a SecondaryHeaderFlag.
-  Unknown
-} 
+    /// The secondary header is not present. The bytes following the primary header
+    /// is the packet's data section.
+    NotPresent,
+    /// A secondary header is present in the packet. The secondary header follows the
+    /// primary header.
+    Present,
+    /// The secondary header flag in not valid. This should not occur, but it is included
+    /// for turning an integer into a SecondaryHeaderFlag.
+    Unknown,
+}
 
 impl Default for SecondaryHeaderFlag {
     fn default() -> SecondaryHeaderFlag {
@@ -113,17 +112,17 @@ impl_sec_header_flag_conv! { u8 u16 }
 ///              packets.
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum SeqFlag {
-  /// The packets is a continuation in a series of packets.
-  Continuation,
-  /// The packets is the first is a series of packets.
-  FirstSegment,
-  /// The packets is the last is a series of packets.
-  LastSegment,
-  /// The packets is a standalone packet. Most packets are unsegmented.
-  Unsegmented,
-  /// The sequence flag is unknown. This should not occur, but it is included
-  /// for encoding integers into this type.
-  Unknown
+    /// The packets is a continuation in a series of packets.
+    Continuation,
+    /// The packets is the first is a series of packets.
+    FirstSegment,
+    /// The packets is the last is a series of packets.
+    LastSegment,
+    /// The packets is a standalone packet. Most packets are unsegmented.
+    Unsegmented,
+    /// The sequence flag is unknown. This should not occur, but it is included
+    /// for encoding integers into this type.
+    Unknown,
 }
 
 impl Default for SeqFlag {
@@ -139,7 +138,7 @@ impl From<u8> for SeqFlag {
             1 => SeqFlag::FirstSegment,
             2 => SeqFlag::LastSegment,
             3 => SeqFlag::Unsegmented,
-            _ => SeqFlag::Unknown
+            _ => SeqFlag::Unknown,
         }
     }
 }
@@ -149,9 +148,9 @@ impl From<SeqFlag> for u16 {
         match byte {
             SeqFlag::Continuation => 0,
             SeqFlag::FirstSegment => 1,
-            SeqFlag::LastSegment  => 2,
-            SeqFlag::Unsegmented  => 3,
-            SeqFlag::Unknown      => 0
+            SeqFlag::LastSegment => 2,
+            SeqFlag::Unsegmented => 3,
+            SeqFlag::Unknown => 0,
         }
     }
 }


### PR DESCRIPTION
There was a TODO in [src/types.rs](src/types.rs) about the jankiness of casting an enum variant to a `u8`, using the [`From`](https://doc.rust-lang.org/std/convert/trait.From.html) trait to convert that to a `u16`, and then applying bitshifting operators to it. The solution is to implement `From` to convert from a `u16` to both a `PacketType` and `SecondaryHeaderFlag` and vice versa, but it gets cumbersome and redundant to implement those traits for similar types. I've added two macros that make it easy for the Rust compiler to automatically generate implementations of the `From` trait for `PacketType` and `SecondaryHeaderFlag` for any (integral) types supplied to the invocations of the macros. I also ran `rustfmt` which is why some seemingly unrelated lines of code have been changed.