### PR TITLE
bump deku dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,9 +23,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.13.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "757c0ded2af11d8e739c4daea1ac623dd1624b06c844cf3f5a39f1bdbd99bb12"
+checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -33,9 +33,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.13.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c34d8efb62d0c2d7f60ece80f75e5c63c1588ba68032740494b0b9a996466e3"
+checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
 dependencies = [
  "fnv",
  "ident_case",
@@ -47,9 +47,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.13.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade7bff147130fe5e6d39f089c6bd49ec0250f35d70b2eebf72afdfc919f15cc"
+checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
 dependencies = [
  "darling_core",
  "quote",
@@ -58,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "deku"
-version = "0.12.4"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54c431132565a4ba57d02759711a71d0d943e5937202c3b3aa46a58b3704f241"
+checksum = "868ccf23869582b2d79279e402db457fe341da24a0c5a8927c6154a5b4733dc3"
 dependencies = [
  "bitvec",
  "deku_derive",
@@ -68,9 +68,9 @@ dependencies = [
 
 [[package]]
 name = "deku_derive"
-version = "0.12.4"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c9dcf8067fe6e8dcef6b1c785db36d271efe30ec4299c765e482d2a6043797"
+checksum = "4dfb4274ccd1c87a598e98b398b4b630aecb2e8a32fd7c88ffa190fb73870f72"
 dependencies = [
  "darling",
  "proc-macro-crate",
@@ -109,18 +109,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.29"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
+checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
 ]
@@ -145,13 +145,13 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.75"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
+checksum = "0748dd251e24453cb8717f0354206b91557e4ec8703673a4b30208f2abaf1ebf"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -190,10 +190,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.2"
+name = "unicode-ident"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
 
 [[package]]
 name = "wyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ exclude = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-deku = "0.12"
+deku = "0.13"

--- a/src/primaryheader.rs
+++ b/src/primaryheader.rs
@@ -48,7 +48,6 @@ pub struct PrimaryHeader {
     #[deku(endian = "big")]
     pub data_length: u16,
     // TODO: maybe figure out if https://docs.rs/deku/0.12.4/deku/#vec is appropriate here
-
 }
 
 #[cfg(test)]
@@ -72,7 +71,7 @@ mod tests {
         let (rest, parsed) = PrimaryHeader::from_bytes((raw, 0)).expect("failed to parse header");
 
         assert_eq!(parsed, expected);
-        assert_eq!(rest.0, [255,255])
+        assert_eq!(rest.0, [255, 255])
     }
 
     #[test]
@@ -94,8 +93,7 @@ mod tests {
 
         let raw = b"\x00\x00\xc0\x00\x00\x40";
 
-        
-        let (rest, parsed) = PrimaryHeader::from_bytes((raw, 0)).expect("failed to parse header");
+        let (_rest, parsed) = PrimaryHeader::from_bytes((raw, 0)).expect("failed to parse header");
 
         assert_eq!(parsed, expected);
     }


### PR DESCRIPTION
Hi!

I would like to use this dependency when converting my `serde`/`postcard` compatible header implementation to this variant for packed serialization. I have some improvements

- Rerun `cargo fmt`
- Fix warning about unused variable
- Bump `deku` dependency to `0.13`. I also re-tested with `cargo test`. I had some issues when converting a `serde` compatible header struct to this `deku` compatible version and then using the `to_bytes()` method. Now it seems to work

If you are interested, I can also provide you my `serde`/`postcard` compatible implementation of the space packet header, but this would probably require to put the implementation in separate `serde` and `deku` submodules because they use different `derive` macros